### PR TITLE
text zoom parameter

### DIFF
--- a/html2bitmap/src/main/java/com/izettle/html2bitmap/Html2Bitmap.java
+++ b/html2bitmap/src/main/java/com/izettle/html2bitmap/Html2Bitmap.java
@@ -27,8 +27,9 @@ public class Html2Bitmap {
     private final int screenshotDelay;
     private boolean strictMode;
     private long timeout;
+    private Integer textZoom;
 
-    private Html2Bitmap(Context context, WebViewContent content, int bitmapWidth, int measureDelay, int screenshotDelay, boolean strictMode, long timeout) {
+    private Html2Bitmap(Context context, WebViewContent content, int bitmapWidth, int measureDelay, int screenshotDelay, boolean strictMode, long timeout, Integer textZoom) {
         this.context = context;
         this.content = content;
         this.bitmapWidth = bitmapWidth;
@@ -36,6 +37,7 @@ public class Html2Bitmap {
         this.screenshotDelay = screenshotDelay;
         this.strictMode = strictMode;
         this.timeout = timeout;
+        this.textZoom = textZoom;
     }
 
     @Nullable
@@ -48,7 +50,7 @@ public class Html2Bitmap {
 
         Handler mainHandler = new Handler(html2Bitmap.context.getMainLooper());
 
-        final Html2BitmapWebView html2BitmapWebView = new Html2BitmapWebView(html2Bitmap.context, html2Bitmap.content, html2Bitmap.bitmapWidth, html2Bitmap.measureDelay, html2Bitmap.screenshotDelay, html2Bitmap.strictMode);
+        final Html2BitmapWebView html2BitmapWebView = new Html2BitmapWebView(html2Bitmap.context, html2Bitmap.content, html2Bitmap.bitmapWidth, html2Bitmap.measureDelay, html2Bitmap.screenshotDelay, html2Bitmap.strictMode, html2Bitmap.textZoom);
         mainHandler.post(new Runnable() {
             @Override
             public void run() {
@@ -88,6 +90,7 @@ public class Html2Bitmap {
         private boolean strictMode = false;
         private long timeout = 15;
         private WebViewContent content;
+        private Integer textZoom = null;
 
         public Builder() {
 
@@ -133,6 +136,11 @@ public class Html2Bitmap {
             return this;
         }
 
+        public Builder setTextZoom(Integer textZoom) {
+            this.textZoom = textZoom;
+            return this;
+        }
+
         public Html2Bitmap build() {
             if (context == null) {
                 throw new NullPointerException();
@@ -140,7 +148,7 @@ public class Html2Bitmap {
             if (content == null) {
                 throw new NullPointerException();
             }
-            return new Html2Bitmap(context, content, bitmapWidth, measureDelay, screenshotDelay, strictMode, timeout);
+            return new Html2Bitmap(context, content, bitmapWidth, measureDelay, screenshotDelay, strictMode, timeout, textZoom);
         }
     }
 }

--- a/html2bitmap/src/main/java/com/izettle/html2bitmap/Html2BitmapWebView.java
+++ b/html2bitmap/src/main/java/com/izettle/html2bitmap/Html2BitmapWebView.java
@@ -39,6 +39,7 @@ class Html2BitmapWebView implements ProgressChangedListener {
     private final int measureDelay;
     private final WebViewContent content;
     private final int bitmapWidth;
+    private final Integer textZoom;
     private final Context context;
     private BitmapCallback callback;
     private WebView webView;
@@ -46,11 +47,12 @@ class Html2BitmapWebView implements ProgressChangedListener {
 
 
     @AnyThread
-    Html2BitmapWebView(@NonNull final Context context, @NonNull final WebViewContent content, final int bitmapWidth, final int measureDelay, final int screenshotDelay, final boolean strictMode) {
+    Html2BitmapWebView(@NonNull final Context context, @NonNull final WebViewContent content, final int bitmapWidth, final int measureDelay, final int screenshotDelay, final boolean strictMode, final Integer textZoom) {
         this.context = context;
         this.content = content;
         this.bitmapWidth = bitmapWidth;
         this.measureDelay = measureDelay;
+        this.textZoom = textZoom;
 
         mainHandler = new Handler(Looper.getMainLooper()) {
             @Override
@@ -127,6 +129,8 @@ class Html2BitmapWebView implements ProgressChangedListener {
         final WebSettings settings = webView.getSettings();
         settings.setBuiltInZoomControls(false);
         settings.setSupportZoom(false);
+        if (textZoom != null)
+            settings.setTextZoom(textZoom);
 
         webView.setWebChromeClient(new WebChromeClient() {
 


### PR DESCRIPTION
Hi,
I encountered to the problem with font size across multiple devices. After some investigation, I found out, problem was with Android font size setting (Settings -> Display -> Font size).
WebView follows this changes, which normally is fine, but in my case, I'm using scale meta tag inside html, which does the work. 
So when I call `setTextZoom(100)` on webview's settings, everything works fine for me.
What do you think about adding this param to the builder? 