### PR TITLE
Remove log statement to prevent ConcurrentModificationException

### DIFF
--- a/html2bitmap/src/main/java/com/izettle/html2bitmap/Html2BitmapWebView.java
+++ b/html2bitmap/src/main/java/com/izettle/html2bitmap/Html2BitmapWebView.java
@@ -151,7 +151,6 @@ class Html2BitmapWebView implements ProgressChangedListener {
             @Override
             public void onProgressChanged(WebView view, int newProgress) {
                 super.onProgressChanged(view, newProgress);
-                Log.i(TAG, "newProgress = " + newProgress + ", " + " progressChanged = " + content.isDone());
                 progress = newProgress;
                 progressChanged();
             }


### PR DESCRIPTION
In some rare cases, logging `content.isDone()` causes `ConcurrentModificationException` as the `webViewResources` is being modified and queried at the same time.
As the log statement does not bring a lot of value, it has been removed.