### PR TITLE
Fix ConcurrentModificationExeption in WebViewContent

### DIFF
--- a/html2bitmap/src/main/java/com/izettle/html2bitmap/content/WebViewContent.java
+++ b/html2bitmap/src/main/java/com/izettle/html2bitmap/content/WebViewContent.java
@@ -14,13 +14,14 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import androidx.annotation.RestrictTo;
 
 public abstract class WebViewContent {
 
 
-    private List<WebViewResource> webViewResources = new ArrayList<>();
+    private final List<WebViewResource> webViewResources = new CopyOnWriteArrayList<>();
     private WeakReference<ProgressChangedListener> doneListenerWeakReference;
 
     /***


### PR DESCRIPTION
This has been present for a long time, but started to occur more frequently recently.

```
Fatal Exception: java.util.ConcurrentModificationException:
       at java.util.ArrayList$Itr.next(ArrayList.java:860)
       at com.izettle.html2bitmap.content.WebViewContent.isDone(WebViewContent.java:45)
       at com.izettle.html2bitmap.content.WebViewContent.resourceLoaded(WebViewContent.java:114)
       at com.izettle.html2bitmap.content.WebViewAssetContent.getAssetFile(WebViewAssetContent.java:63)
       at com.izettle.html2bitmap.content.WebViewAssetContent.loadResourceImpl(WebViewAssetContent.java:31)
       at com.izettle.html2bitmap.content.WebViewContent.loadResource(WebViewContent.java:62)
       at com.izettle.html2bitmap.Html2BitmapWebView$4.shouldInterceptRequest(Html2BitmapWebView.java:181)
       at com.izettle.payments.android.core.AppInfoImpl.cleaned(AppInfo.kt:93)
       at org.chromium.android_webview.AwContentsBackgroundThreadClient.shouldInterceptRequestFromNative(chromium-TrichromeWebViewGoogle.aab-stable-561504833:15)
```